### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+`datascience` ChangeLog
+=======================
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Added
+- This CHANGELOG file!
+- Docs are now up on [readthedocs][rtd].
+- [`util.table_apply` function][table_apply]
+
+[rtd]: http://datascience.readthedocs.org/en/latest/index.html
+[table_apply]: https://github.com/data-8/datascience/blob/f7c11b5132299dab0c75a5862cdab9c5b619c7e5/datascience/util.py#L62-L82


### PR DESCRIPTION
Hooray! Now we'll start documenting changes in `CHANGELOG.md`.
The changes currently listed are the ones after the `v0.3.dev22`
release.

Closes #149.