### PR TITLE
Throwing an error when data8.berkeley.edu URL is passed

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -117,8 +117,12 @@ class Table(collections.abc.MutableMapping):
         # Look for .csv at the end of the path; use "," as a separator if found
         try:
             path = urllib.parse.urlparse(filepath_or_buffer).path
+            if 'data8.berkeley.edu' in filepath_or_buffer:
+                raise ValueError('data8.berkeley.edu requires authentication, '
+                                 'which is not supported.')
         except AttributeError:
             path = filepath_or_buffer
+
         try:
             if 'sep' not in vargs and path.endswith('.csv'):
                 vargs['sep'] = ','

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -2,7 +2,6 @@ import doctest
 import re
 import pytest
 import numpy as np
-from nose.tools import assert_raises
 from numpy.testing import assert_array_equal
 from datascience import *
 import pandas as pd
@@ -1043,5 +1042,6 @@ def test_array_roundtrip(table):
 
 def test_url_parse():
     """Test that Tables parses URLs correctly"""
-    url = 'https://data8.berkeley.edu/something/something/dark/side'
-    assert_raises(ValueError, Table.read_table, url)
+    with pytest.raises(ValueError):
+        url = 'https://data8.berkeley.edu/something/something/dark/side'
+        Table.read_table(url)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -2,6 +2,7 @@ import doctest
 import re
 import pytest
 import numpy as np
+from nose.tools import assert_raises
 from numpy.testing import assert_array_equal
 from datascience import *
 import pandas as pd
@@ -1038,3 +1039,9 @@ def test_array_roundtrip(table):
 
     for (c0, c1) in zip(t.columns, table.columns):
         assert_equal(c0, c1)
+
+
+def test_url_parse():
+    """Test that Tables parses URLs correctly"""
+    url = 'https://data8.berkeley.edu/something/something/dark/side'
+    assert_raises(ValueError, Table.read_table, url)


### PR DESCRIPTION
Throws a warning when `read_table` gets a URL with data8.berkeley.edu in it. Otherwise it will break w/ an unhelpful error because of authentication problems. See #184 