### PR TITLE
Fix bug that had got introduced some time ago in pivot_bin

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -712,15 +712,15 @@ class Table(collections.abc.MutableMapping):
         """
         pivot_columns = _as_labels(pivot_columns)
         selected = self.select(pivot_columns + [value_column])
-        grouped=selected.groups(pivot_columns)
-
+        grouped=selected.groups(pivot_columns, collect=lambda x:x ) 
+        
         # refine bins by taking a histogram over all the data
         if bins is not None:
             vargs['bins'] = bins
         _, rbins = np.histogram(self[value_column],**vargs)
         # create a table with these bins a first column and counts for each group
         vargs['bins'] = rbins
-        binned = Table([rbins],['bin'])
+        binned = Table().with_column('bin',rbins)
         for group in grouped.rows:
             col_label = "-".join(map(str,group[0:-1]))
             col_vals = group[-1]

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -49,6 +49,17 @@ def numbers_table():
         'points', [1, 2, 2, 10],
         ])
 
+@pytest.fixture(scope='function')
+def categories_table():
+    """Setup a table with a column to serve as pivot keys and
+    a columns of values to bin for each key."""
+    return Table(['key', 'val']).with_rows([
+            ['a', 1],
+            ['a', 1],
+            ['a', 2],
+            ['b', 1],
+            ['b', 2],
+            ['b', 2]])
 
 @pytest.fixture(scope='module')
 def t():
@@ -910,6 +921,15 @@ def test_percentile(numbers_table):
     assert_equal(numbers_table.percentile(66), """
     count | points
     3     | 2
+    """)
+
+def test_pivot_bin(categories_table):
+    assert_equal(categories_table.pivot_bin('key', 'val', bins=[0, 1, 2, 3]), """
+    bin  | a    | b
+    0    | 0    | 0
+    1    | 2    | 1
+    2    | 1    | 2
+    3    | 0    | 0
     """)
 
 ##################


### PR DESCRIPTION
pivot_bin failed to group entries associated with a key, which would then be binned.
Further fix to pivot_bin to remove deprecated construction.
Introduced test that would have caught the bug.