### PR TITLE
Under-the-hood changes for table.values

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -279,7 +279,7 @@ class Table(collections.abc.MutableMapping):
             dtype = object
         else:
             dtype = None
-        return np.array(self.rows, dtype=dtype)
+        return np.array(self.columns, dtype=dtype).T
 
     def column_index(self, column_label):
         """Return the index of a column."""


### PR DESCRIPTION
[ ] Wrote test for feature
[ ] Added note about PR in CHANGELOG.md

**Changes proposed:**
This is a backend change to the Table.values property. Somewhere recently the behavior of `table.rows` changed to return a `Rows` object instead of a list of arrays (which is what `table.columns` does). This was taking a looong time when passed to `np.array`, so I'm changing it to use `table.columns` instead. We should think of a different solution if the plan is to change the output of `table.columns` as well.