### PR TITLE
Fixes bug in Issue 204

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -552,6 +552,8 @@ class Table(collections.abc.MutableMapping):
                 self._formats[old_to_new[label]] = formatter
         return self
 
+    
+
 
     ##################
     # Transformation #

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -400,7 +400,7 @@ class Table(collections.abc.MutableMapping):
             columns = list(t.select(self.labels)._columns.values())
             n = t.num_rows
         else:
-            if (len(row_or_table) != self.num_columns):
+            if (len(list(row_or_table)) != self.num_columns):
                 raise Exception('Row should have '+ str(self.num_columns) + " columns")
             columns, n = [[value] for value in row_or_table], 1
         for i, column in enumerate(self._columns):

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -400,6 +400,8 @@ class Table(collections.abc.MutableMapping):
             columns = list(t.select(self.labels)._columns.values())
             n = t.num_rows
         else:
+            if (len(row_or_table) != self.num_columns):
+                raise Exception('Row should have '+ str(self.num_columns) + " columns")
             columns, n = [[value] for value in row_or_table], 1
         for i, column in enumerate(self._columns):
             if self.num_rows:

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -530,6 +530,18 @@ def test_append_row(table):
     g      | 2     | 2
     """)
 
+
+def test_append_row_different_num_cols(table):
+    """Makes sure that any incoming row must have the same amount of columns as the table."""
+    row = "abcd"
+    with(pytest.raises(Exception)):
+        table.append(row)
+
+    row = ["e", 2, 4, 6]
+    with(pytest.raises(Exception)):
+        table.append(row)
+
+
 def test_append_column(table):
     column_1 = [10, 20, 30, 40]
     column_2 = 'hello'


### PR DESCRIPTION
Check arguments for Table.append to only accept row with the same amount of elements as columns of the table

[*] Wrote test for feature

**Changes proposed:**
Check the length of the inserting row and make sure it matches the number of columns the table has before adding the row into the table.
