### PR TITLE
Faster Table.split

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -1471,15 +1471,16 @@ class Table(collections.abc.MutableMapping):
             raise ValueError("Invalid value of k. k must be between 1 and the"
                              "number of rows - 1")
 
-        rows = [self.rows[index] for index in
-                np.random.permutation(self.num_rows)]
+        rows = np.random.permutation(self.num_rows)
         cls = type(self)
-        first = cls(self.labels).with_rows(rows[:k])
-        rest = cls(self.labels).with_rows(rows[k:])
+        first = cls(self.labels).with_rows([self.rows[index] for index in rows[:k]])
+        rest = cls(self.labels).with_rows([self.rows[index] for index in rows[k:]])
         for column_label in self._formats:
             first._formats[column_label] = self._formats[column_label]
             rest._formats[column_label] = self._formats[column_label]
         return first, rest
+
+
 
     def with_row(self, row):
         """Return a table with an additional row.

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -1481,7 +1481,6 @@ class Table(collections.abc.MutableMapping):
         return first, rest
 
 
-
     def with_row(self, row):
         """Return a table with an additional row.
 

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -1472,9 +1472,9 @@ class Table(collections.abc.MutableMapping):
                              "number of rows - 1")
 
         rows = np.random.permutation(self.num_rows)
-        cls = type(self)
-        first = cls(self.labels).with_rows([self.rows[index] for index in rows[:k]])
-        rest = cls(self.labels).with_rows([self.rows[index] for index in rows[k:]])
+
+        first = self.take(rows[:k])
+        rest = self.take(rows[k:])
         for column_label in self._formats:
             first._formats[column_label] = self._formats[column_label]
             rest._formats[column_label] = self._formats[column_label]

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1031,6 +1031,11 @@ def test_split_k_vals(table):
     with pytest.raises(ValueError):
         table.split(table.num_rows)
 
+def test_split_table_labels(table):
+    sampled, rest = table.split(3)
+    assert sampled.labels == table.labels
+    assert rest.labels == table.labels
+
 #############
 # Visualize #
 #############


### PR DESCRIPTION
**Changes proposed:**
Changed Table.split so that it utilizes Table.take, which helps us split the table much faster than copying the rows multiple times.
