### PR TITLE
Column formatting join clean

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -1245,8 +1245,7 @@ class Table(collections.abc.MutableMapping):
             return None
 
         labels = list(self.labels)
-        new_labels = [self._unused_label(s) for s in other.labels]
-        labels += new_labels
+        labels += [self._unused_label(s) for s in other.labels]
         joined = type(self)(labels).with_rows(joined_rows)
         for selfformat in self._formats:
             joined.set_format(selfformat, self._formats[selfformat])

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -1245,10 +1245,19 @@ class Table(collections.abc.MutableMapping):
             return None
 
         labels = list(self.labels)
-        labels += [self._unused_label(s) for s in other.labels]
+        new_labels = [self._unused_label(s) for s in other.labels]
+        labels += new_labels
         joined = type(self)(labels).with_rows(joined_rows)
+        for selfformat in self._formats:
+            joined.set_format(selfformat, self._formats[selfformat])
+        for otherformat in other._formats:
+            if otherformat in joined.labels:
+                joined.set_format(self._unused_label(otherformat), other._formats[otherformat])
+            else:
+                joined.set_format(otherformat, other._formats[otherformat])
         del joined[self._unused_label(other_label)] # Remove redundant column
         return joined.move_to_start(column_label).sort(column_label)
+
 
     def stats(self, ops=(min, max, np.median, sum)):
         """Compute statistics for each column and place them in a table."""

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -923,6 +923,78 @@ def test_join_with_strings(table):
     z      | 1     | 10     | 1       | 10
     """)
 
+def test_join_with_same_formats(table):
+    test = table.copy().set_format("points", CurrencyFormatter)
+    assert_equal(test, """
+    letter | count | points
+    a      | 9     | $1.00
+    b      | 3     | $2.00
+    c      | 3     | $2.00
+    z      | 1     | $10.00
+    """)
+    test_joined = test.join("points", test)
+    assert_equal(test_joined, """
+    points | letter | count | letter_2  | count_2
+    $1.00  | a      | 9     | a         | 9     
+    $2.00  | b      | 3     | b         | 3     
+    $2.00  | c      | 3     | b         | 3     
+    $10.00 | z      | 1     | z         | 1     
+    """)
+
+def test_join_with_one_formatted(table):
+    test = table.copy().set_format("points", CurrencyFormatter)
+    assert_equal(test, """
+    letter | count | points
+    a      | 9     | $1.00
+    b      | 3     | $2.00
+    c      | 3     | $2.00
+    z      | 1     | $10.00
+    """)
+    test_joined = test.join("points", table)
+    assert_equal(test_joined, """
+    points | letter | count | letter_2  | count_2
+    $1.00  | a      | 9     | a         | 9     
+    $2.00  | b      | 3     | b         | 3     
+    $2.00  | c      | 3     | b         | 3     
+    $10.00 | z      | 1     | z         | 1     
+    """)
+
+def test_join_with_two_labels_one_format(table):
+    test = table.copy().set_format("points", CurrencyFormatter)
+    assert_equal(test, """
+    letter | count | points
+    a      | 9     | $1.00
+    b      | 3     | $2.00
+    c      | 3     | $2.00
+    z      | 1     | $10.00
+    """)
+    assert_equal(table, """
+    letter | count | points
+    a      | 9     | 1
+    b      | 3     | 2
+    c      | 3     | 2
+    z      | 1     | 10
+    """)
+    test2 = test.copy()
+    table2 = table.copy()
+    test_joined = test.join("letter", table)
+    assert_equal(test_joined, """
+    letter | count | points     | count_2 | points_2
+    a      | 9     | $1.00      | 9       | 1
+    b      | 3     | $2.00      | 3       | 2
+    c      | 3     | $2.00      | 3       | 2
+    z      | 1     | $10.00     | 1       | 10
+    """)
+
+    test_joined2 = table2.join("letter", test2)
+    assert_equal(test_joined2, """
+    letter | count | points | count_2 | points_2
+    a      | 9     | 1      | 9       | $1.00
+    b      | 3     | 2      | 3       | $2.00
+    c      | 3     | 2      | 3       | $2.00
+    z      | 1     | 10     | 1       | $10.00
+    """)
+
 def test_percentile(numbers_table):
     assert_equal(numbers_table.percentile(76), """
     count | points


### PR DESCRIPTION
[*] Wrote test for feature

**Changes proposed:**
Made it so that self's formats take precedence over other's formats in a column that is being joined and in other columns, other's formats will only apply to the columns it contributed to joined (same for self).
