### PR TITLE
Fix minor formatting issues with Table.as_html 

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -1872,8 +1872,8 @@ class Table(collections.abc.MutableMapping):
                 (3, ' '.join('<td>' + fmt(v, label=False) + '</td>' for
                     v, fmt in zip(row, fmts))),
                 (2, '</tr>'),
-                (1, '</tbody>'),
             ]
+        lines.append((1, '</tbody>'))
         lines.append((0, '</table>'))
         if omitted:
             lines.append((0, '<p>... ({} rows omitted)</p>'.format(omitted)))

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -1876,7 +1876,7 @@ class Table(collections.abc.MutableMapping):
             ]
         lines.append((0, '</table>'))
         if omitted:
-            lines.append((0, '<p>... ({} rows omitted)</p'.format(omitted)))
+            lines.append((0, '<p>... ({} rows omitted)</p>'.format(omitted)))
         return '\n'.join(4 * indent * ' ' + text for indent, text in lines)
 
     def index_by(self, column_or_label):


### PR DESCRIPTION
- [ ] Wrote test for feature 
- [ ] Added changes in the Changelog section in README.md
- [ ] Bumped version number (delete if unneeded)

I did not do any of the above - sorry. Writing a test would be a good idea ... maybe I'll add one. 

I came across these when working on table rendering for okpy.org (https://github.com/Cal-CS-61A-Staff/ok/pull/1099)

**Changes proposed:**
- 92ed686 fixes the `</p>` tag that occurs when rows in the table are omitted
- 38dcdc8 makes the `</tbody>` tag appear only once per table. Currently one appears for every row - despite only having one opening `<tbody>` tag. 

