### PR TITLE
Add plt.show() to all plotting calls

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -2276,6 +2276,7 @@ class Table(collections.abc.MutableMapping):
                 if ticks is not None:
                     annotate(axis, ticks)
                 type(self).plots.append(axis)
+        plt.show()
 
     def _split_column_and_labels(self, column_or_label):
         """Return the specified column and labels of other columns."""
@@ -2313,6 +2314,7 @@ class Table(collections.abc.MutableMapping):
         t['end'] = bins[1:]
         for label, column in zip(pvt_labels,vals):
             t[label] = column
+        plt.show()
 
     def hist(self, *columns, overlay=True, bins=None, bin_column=None, unit=None, counts=None, width=6, height=4, **vargs):
         """Plots one histogram for each column in columns. If no column is
@@ -2440,6 +2442,7 @@ class Table(collections.abc.MutableMapping):
                 axis.hist(values, color=color, **vargs)
                 _vertical_x(axis)
                 type(self).plots.append(axis)
+        plt.show()
 
     def boxplot(self, **vargs):
         """Plots a boxplot for the table.
@@ -2487,6 +2490,7 @@ class Table(collections.abc.MutableMapping):
         vargs['labels'] = columns.keys()
         values = list(columns.values())
         plt.boxplot(values, **vargs)
+        plt.show()
 
 
     ###########


### PR DESCRIPTION
This doesn't change current behavior at all. However, without it the
plot gets displayed multiple times when using IPython's widgets as I'm
discovering now.

I've tested this by calling each plot method and verifying that the
notebook output is the same. In addition, I've verified that using IPython
widgets does not duplicate plots when redrawn:

![interact](https://cloud.githubusercontent.com/assets/2468904/23538103/8e8ebe5c-ff85-11e6-817b-ca1527c5aa87.gif)
