### PR TITLE
folium version bump and api change

### DIFF
--- a/datascience/maps.py
+++ b/datascience/maps.py
@@ -49,16 +49,7 @@ class _FoliumWrapper(abc.ABC):
     @staticmethod
     def _inline_map(m, width, height):
         """Returns an embedded iframe of a folium.map."""
-        m._build_map()
-        src = m.HTML.replace('"', '&quot;')
-        style = "width: {}px; height: {}px".format(width, height)
-        html = '<iframe srcdoc="{}" style="{}"; border: none"></iframe>'.format(src, style)
-        # See https://github.com/python-visualization/folium/issues/176
-        if hasattr(m, 'json_data'):
-            for name, data in m.json_data.items():
-                stub = 'function(callback){callback(null, JSON.parse('
-                replace = stub + repr(json.dumps(data).replace('"', '&quot;')) + '))}'
-                html = html.replace('d3.json, ' + repr(name), replace)
+        html = m._repr_html_()
         return html
 
     @abc.abstractmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-folium==0.1.5
+folium==0.2.1
 sphinx
 setuptools


### PR DESCRIPTION
**Changes proposed:**

This bumps the version of folium to 0.2.1 so that it no longer has messy HTML output in the iframe. The version bump also fixed an HTML bug that (I think) required the datascience package to hack around, so I'm removing the "hack around this bug" code as well.
