### PR TITLE
Fix test_scatter_error. 

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1261,7 +1261,7 @@ def test_scatter_error(table):
     non-numerical values."""
 
     with pytest.raises(ValueError):
-        table.scatter('letter')
+        table.scatter('nonexistentlabel')
 
 def test_df_roundtrip(table):
     df = table.to_df()


### PR DESCRIPTION
**Changes proposed:**
test_scatter_error() looks like a bogus test to me.  I'm not sure how this test ever worked.  One of the example tables *does* have a column called `letter`, so it shouldn't raise a ValueError.  Correct the test so it will fail properly.