### PR TITLE
Update tests to reflect comma separators inserted by default formatter

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -515,15 +515,15 @@ class Table(collections.abc.MutableMapping):
         ...     'id',     make_array(12345, 123, 5123))
         >>> table.relabel('id', 'yolo')
         points | yolo
-        1      | 12345
+        1      | 12,345
         2      | 123
-        3      | 5123
+        3      | 5,123
         >>> table.relabel(make_array('points', 'yolo'),
         ...   make_array('red', 'blue'))
         red  | blue
-        1    | 12345
+        1    | 12,345
         2    | 123
-        3    | 5123
+        3    | 5,123
         >>> table.relabel(make_array('red', 'green', 'blue'),
         ...   make_array('cyan', 'magenta', 'yellow', 'key'))
         Traceback (most recent call last):
@@ -1640,21 +1640,21 @@ class Table(collections.abc.MutableMapping):
         >>> players = Table().with_columns('player_id',
         ...     make_array(110234, 110235), 'wOBA', make_array(.354, .236))
         >>> players
-        player_id | wOBA
-        110234    | 0.354
-        110235    | 0.236
+        player_id  | wOBA
+        110,234    | 0.354
+        110,235    | 0.236
         >>> players = players.with_columns('salaries', 'N/A', 'season', 2016)
         >>> players
-        player_id | wOBA  | salaries | season
-        110234    | 0.354 | N/A      | 2016
-        110235    | 0.236 | N/A      | 2016
+        player_id  | wOBA  | salaries | season
+        110,234    | 0.354 | N/A      | 2,016
+        110,235    | 0.236 | N/A      | 2,016
         >>> salaries = Table().with_column('salary',
         ...     make_array('$500,000', '$15,500,000'))
         >>> players.with_columns('salaries', salaries.column('salary'),
         ...     'years', make_array(6, 1))
-        player_id | wOBA  | salaries    | season | years
-        110234    | 0.354 | $500,000    | 2016   | 6
-        110235    | 0.236 | $15,500,000 | 2016   | 1
+        player_id  | wOBA  | salaries    | season  | years
+        110,234    | 0.354 | $500,000    | 2,016   | 6
+        110,235    | 0.236 | $15,500,000 | 2,016   | 1
         >>> players.with_columns(2, make_array('$600,000', '$20,000,000'))
         Traceback (most recent call last):
             ...

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -19,8 +19,8 @@ def test_doctests():
 def test_default_format():
     fmt = ds.default_formatter.format_value
     assert_equal(fmt(1.23456789), '1.23457')
-    assert_equal(fmt(123456789), '123456789')
-    assert_equal(fmt(123456789**5), '28679718602997181072337614380936720482949')
+    assert_equal(fmt(123456789), '123,456,789')
+    assert_equal(fmt(123456789**5), '28,679,718,602,997,181,072,337,614,380,936,720,482,949')
     assert_equal(fmt(123.456789**5), '2.86797e+10')
     assert_equal(fmt(True), 'True')
     assert_equal(fmt(False), 'False')

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -696,23 +696,23 @@ def test_relabel():
     table.relabel('id', 'todo')
     assert_equal(table, """
     points | todo
-    1      | 12345
+    1      | 12,345
     2      | 123
-    3      | 5123
+    3      | 5,123
     """)
     table.relabel(1, 'yolo')
     assert_equal(table, """
     points | yolo
-    1      | 12345
+    1      | 12,345
     2      | 123
-    3      | 5123
+    3      | 5,123
     """)
     table.relabel(['points', 'yolo'], ['red', 'blue'])
     assert_equal(table, """
     red    | blue
-    1      | 12345
+    1      | 12,345
     2      | 123
-    3      | 5123
+    3      | 5,123
     """)
     with(pytest.raises(ValueError)):
         table.relabel(['red', 'blue'], ['magenta', 'cyan', 'yellow'])


### PR DESCRIPTION
Our current default formatter inserts comma separators into numbers (e.g., 1,234 instead of 1234).  Updating the tests to reflect this.

If the current behavior is not the correct behavior, then this PR should be rejected and the default formatter should be fixed.