### PR TITLE
Fixed append_columns() function

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -489,6 +489,7 @@ class Table(collections.abc.MutableMapping):
             self._num_rows = len(values)
 
         self._columns[label] = values
+        return self
 
     def relabel(self, column_label, new_label):
         """Changes the label(s) of column(s) specified by ``column_label`` to


### PR DESCRIPTION
This function, according to the docs, modifies the table in place but also returns a handle to the table for further chaining. This behavior did not work as expected because someone probably forgot to return self.

[ ] Wrote test for feature
[ ] Added changes in the Changelog section in README.md
[ ] Bumped version number (delete if unneeded)

**Changes proposed:**
<description of the PR>
