### PR TITLE
Update read_table to pandas 0.42 read_csv

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -129,7 +129,7 @@ class Table(collections.abc.MutableMapping):
                 vargs['sep'] = ','
         except AttributeError:
             pass
-        df = pandas.read_table(filepath_or_buffer, *args, **vargs)
+        df = pandas.read_csv(filepath_or_buffer, *args, **vargs)
         return cls.from_df(df)
 
     def _with_columns(self, columns):

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1332,3 +1332,7 @@ def test_url_parse():
     with pytest.raises(ValueError):
         url = 'https://data8.berkeley.edu/something/something/dark/side'
         Table.read_table(url)
+
+def test_read_table():
+    """Test that Tables reads a csv file."""
+    assert isinstanceof(Table, Table().read_table("tests/us-unemployment.csv"))


### PR DESCRIPTION
[ X] Wrote test for feature
[ ] Added changes in the Changelog section in README.md
[ ] Bumped version number (delete if unneeded)

**Changes proposed:**
Updates read_table function to use pandas.read_csv rather than pandas.read_table, which was deprecated 0.24
