### PR TITLE
Fix warnings when building docs

### DIFF
--- a/datascience/maps.py
+++ b/datascience/maps.py
@@ -505,16 +505,16 @@ class Circle(Marker):
     fill_opacity: float, default 0.6
         Circle fill opacity
 
-    For example, to draw three circles:
+    For example, to draw three circles::
 
-    t = Table().with_columns([
-            'lat', [37.8, 38, 37.9],
-            'lon', [-122, -122.1, -121.9],
-            'label', ['one', 'two', 'three'],
-            'color', ['red', 'green', 'blue'],
-            'radius', [3000, 4000, 5000],
-        ])
-    Circle.map_table(t)
+        t = Table().with_columns([
+                'lat', [37.8, 38, 37.9],
+                'lon', [-122, -122.1, -121.9],
+                'label', ['one', 'two', 'three'],
+                'color', ['red', 'green', 'blue'],
+                'radius', [3000, 4000, 5000],
+            ])
+        Circle.map_table(t)
     """
 
     _map_method_name = 'circle_marker'

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -1459,11 +1459,11 @@ class Table(collections.abc.MutableMapping):
         job  | wage
         a    | 10
         a    | 10
-        >>> jobs.sample(k=2, weights=make_array(1, 0, 1, 0)) # Weights must be length of table.
+        >>> jobs.sample(k=2, weights=make_array(1, 0, 1, 0))
         Traceback (most recent call last):
             ...
         ValueError: probabilities do not sum to 1
-        >>> jobs.sample(k=2, weights=make_array(1, 0, 0))
+        >>> jobs.sample(k=2, weights=make_array(1, 0, 0)) # Weights must be length of table.
         Traceback (most recent call last):
             ...
         ValueError: 'a' and 'p' must have same size

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -308,8 +308,9 @@ class Table(collections.abc.MutableMapping):
         If no ``column_or_columns`` provided, `fn`` is applied to each row.
 
         Args:
-            ``fn`` (function) -- The function to apply.
-            ``column_or_columns``: Columns containing the arguments to ``fn``
+            ``fn`` (function) -- The function to apply to each element
+                of ``column_or_columns``.
+            ``column_or_columns`` -- Columns containing the arguments to ``fn``
                 as either column labels (``str``) or column indices (``int``).
                 The number of columns must match the number of arguments
                 that ``fn`` expects.
@@ -1059,7 +1060,8 @@ class Table(collections.abc.MutableMapping):
                 Default None.
             ``collect`` -- aggregation function, used to group ``values``
                 over row-column combinations. Default None.
-            ``zero`` -- zero value for non-existent row-column combinations.
+            ``zero`` -- zero value to use for non-existent row-column
+                combinations.
 
         Raises:
             TypeError -- if ``collect`` is passed in and ``values`` is not,
@@ -1460,7 +1462,6 @@ class Table(collections.abc.MutableMapping):
         Traceback (most recent call last):
             ...
         ValueError: probabilities do not sum to 1
-
         # Weights must be length of table.
         >>> jobs.sample(k=2, weights=make_array(1, 0, 0))
         Traceback (most recent call last):
@@ -2041,6 +2042,7 @@ class Table(collections.abc.MutableMapping):
             Returns a line plot (connected scatter). Each plot is labeled using
             the values in `column_for_xticks` and one plot is produced for all
             other columns in self (or for the columns designated by `select`).
+
         >>> table = Table().with_columns(
         ...     'days',  make_array(0, 1, 2, 3, 4, 5),
         ...     'price', make_array(90.5, 90.00, 83.00, 95.50, 82.00, 82.00),

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -1459,11 +1459,10 @@ class Table(collections.abc.MutableMapping):
         job  | wage
         a    | 10
         a    | 10
-        >>> jobs.sample(k=2, weights=make_array(1, 0, 1, 0))
+        >>> jobs.sample(k=2, weights=make_array(1, 0, 1, 0)) # Weights must be length of table.
         Traceback (most recent call last):
             ...
         ValueError: probabilities do not sum to 1
-        # Weights must be length of table.
         >>> jobs.sample(k=2, weights=make_array(1, 0, 0))
         Traceback (most recent call last):
             ...

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -241,6 +241,7 @@ class Table(collections.abc.MutableMapping):
 
     @property
     def columns(self):
+        """Return a tuple of columns, each with the values in that column."""
         return tuple(self._columns.values())
 
     def column(self, index_or_label):

--- a/datascience/util.py
+++ b/datascience/util.py
@@ -161,20 +161,15 @@ def proportions_from_distribution(table, label, sample_size,
 def table_apply(table, func, subset=None):
     """Applies a function to each column and returns a Table.
 
-    Uses pandas `apply` under the hood, then converts back to a Table
-
     Args:
-        table : instance of Table
-            The table to apply your function to
-        func : function
-            Any function that will work with DataFrame.apply
-        subset : list | None
-            A list of columns to apply the function to. If None, function
-            will be applied to all columns in table
+        ``table``: The table to apply your function to.
 
-    Returns
-    -------
-    tab : instance of Table
+        ``func``: The function to apply to each column.
+
+        ``subset``: A list of columns to apply the function to; if None,
+            the function will be applied to all columns in table.
+
+    Returns:
         A table with the given function applied. It will either be the
         shape == shape(table), or shape (1, table.shape[1])
     """

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -312,11 +312,11 @@ For more examples, check out `the TableDemos repo`_.
 From the text:
 
     The table ``baby`` contains data on a random sample of 1,174 mothers and
-    their newborn babies. The column ``birthwt`` contains the birth weight of
-    the baby, in ounces; ``gest_days`` is the number of gestational days, that
-    is, the number of days the baby was in the womb. There is also data on
-    maternal age, maternal height, maternal pregnancy weight, and whether or not
-    the mother was a smoker.
+    their newborn babies. The column ``Birth Weight`` contains the birth weight
+    of the baby, in ounces; ``Gestational Days`` is the number of gestational
+    days, that is, the number of days the baby was in the womb. There is also
+    data on maternal age, maternal height, maternal pregnancy weight, and
+    whether or not the mother was a smoker.
 
 .. ipython:: python
 
@@ -324,7 +324,7 @@ From the text:
     baby # Let's take a peek at the table
 
     # Select out columns we want.
-    smoker_and_wt = baby.select(['m_smoker', 'birthwt'])
+    smoker_and_wt = baby.select(['Maternal Smoker', 'Birth Weight'])
     smoker_and_wt
 
 Let's compare the number of smokers to non-smokers.
@@ -332,7 +332,7 @@ Let's compare the number of smokers to non-smokers.
 .. ipython:: python
 
     @savefig m_smoker.png width=4in
-    smoker_and_wt.select('m_smoker').hist(bins = [0, 1, 2]);
+    smoker_and_wt.select('Maternal Smoker').hist(bins = [0, 1, 2]);
 
 We can also compare the distribution of birthweights between smokers and
 non-smokers.
@@ -343,18 +343,18 @@ non-smokers.
     # We do this by grabbing the rows that correspond to mothers that don't
     # smoke, then plotting a histogram of just the birthweights.
     @savefig not_m_smoker_weights.png width=4in
-    smoker_and_wt.where('m_smoker', 0).select('birthwt').hist()
+    smoker_and_wt.where('Maternal Smoker', 0).select('Birth Weight').hist()
 
     # Smokers
     @savefig m_smoker_weights.png width=4in
-    smoker_and_wt.where('m_smoker', 1).select('birthwt').hist()
+    smoker_and_wt.where('Maternal Smoker', 1).select('Birth Weight').hist()
 
 What's the difference in mean birth weight of the two categories?
 
 .. ipython:: python
 
-    nonsmoking_mean = smoker_and_wt.where('m_smoker', 0).column('birthwt').mean()
-    smoking_mean = smoker_and_wt.where('m_smoker', 1).column('birthwt').mean()
+    nonsmoking_mean = smoker_and_wt.where('Maternal Smoker', 0).column('Birth Weight').mean()
+    smoking_mean = smoker_and_wt.where('Maternal Smoker', 1).column('Birth Weight').mean()
 
     observed_diff = nonsmoking_mean - smoking_mean
     observed_diff
@@ -363,7 +363,7 @@ Let's do the bootstrap test on the two categories.
 
 .. ipython:: python
 
-    num_nonsmokers = smoker_and_wt.where('m_smoker', 0).num_rows
+    num_nonsmokers = smoker_and_wt.where('Maternal Smoker', 0).num_rows
     def bootstrap_once():
         """
         Computes one bootstrapped difference in means.
@@ -371,8 +371,8 @@ Let's do the bootstrap test on the two categories.
         We then split according to the number of nonsmokers in the original sample.
         """
         resample = smoker_and_wt.sample(with_replacement = True)
-        bootstrap_diff = resample.column('birthwt')[:num_nonsmokers].mean() - \
-            resample.column('birthwt')[num_nonsmokers:].mean()
+        bootstrap_diff = resample.column('Birth Weight')[:num_nonsmokers].mean() - \
+            resample.column('Birth Weight')[num_nonsmokers:].mean()
         return bootstrap_diff
 
     repetitions = 1000

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -10,7 +10,7 @@ For other useful tutorials and examples, see:
 - `The textbook introduction to Tables`_
 - `Example notebooks`_
 
-.. _The textbook introduction to Tables: http://www.inferentialthinking.com/chapter1/tables.html
+.. _The textbook introduction to Tables: https://www.inferentialthinking.com/chapters/06/Tables.html
 .. _Example notebooks: https://github.com/deculler/TableDemos
 
 .. contents:: Table of Contents
@@ -89,7 +89,7 @@ CSVs from URLs are also valid inputs to
 
 .. ipython:: python
 
-    Table.read_table('http://data8.org/textbook/notebooks/sat2014.csv')
+    Table.read_table('https://www.inferentialthinking.com/data/sat2014.csv')
 
 ------
 
@@ -300,13 +300,13 @@ converting to a pandas dataframe with :meth:`~datascience.tables.Table.to_df`:
 An Example
 ----------
 
-We'll recreate the steps in `Chapter 3 of the textbook`_ to see if there is a
+We'll recreate the steps in `Chapter 12 of the textbook`_ to see if there is a
 significant difference in birth weights between smokers and non-smokers using a
 bootstrap test.
 
 For more examples, check out `the TableDemos repo`_.
 
-.. _Chapter 3 of the textbook: http://data8.org/text/3_inference.html#Using-the-Bootstrap-Method-to-Test-Hypotheses
+.. _Chapter 12 of the textbook: https://www.inferentialthinking.com/chapters/12/1/AB_Testing.html
 .. _the TableDemos repo: https://github.com/deculler/TableDemos
 
 From the text:
@@ -320,7 +320,7 @@ From the text:
 
 .. ipython:: python
 
-    baby = Table.read_table('https://github.com/data-8/textbook/raw/9aa0a167bc514749338cd7754f2b339fd095ee9b/notebooks/baby.csv')
+    baby = Table.read_table('https://www.inferentialthinking.com/data/baby.csv')
     baby # Let's take a peek at the table
 
     # Select out columns we want.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -331,8 +331,7 @@ Let's compare the number of smokers to non-smokers.
 
 .. ipython:: python
 
-    @savefig m_smoker.png width=4in
-    smoker_and_wt.select('Maternal Smoker').hist(bins = [0, 1, 2]);
+    smoker_and_wt.select('Maternal Smoker').group('Maternal Smoker')
 
 We can also compare the distribution of birthweights between smokers and
 non-smokers.


### PR DESCRIPTION
**Changes proposed:**
Updates the tests to eliminate most of the warnings when running `make docs`, and clean up some outdated/obsolete links.  Partly addresses #357.