### PR TITLE
Remove libgfortran dependency

### DIFF
--- a/linux_environment.yml
+++ b/linux_environment.yml
@@ -8,7 +8,6 @@ dependencies:
 - freetype
 - ipython
 - ipython_genutils
-- libgfortran
 - libpng
 - libxml2
 - matplotlib
@@ -51,4 +50,3 @@ dependencies:
   - snowballstemmer
   - sphinx
   - sphinx-rtd-theme
-


### PR DESCRIPTION
**Changes proposed:**
Builds on Travis were failing because of a dependency on installing `libgfortran` via conda.  I'm not sure that we ever used that for anything, so I removed it; everything still seems to work.
