### PR TITLE
remove deprecation warning from matplotlib v3.1+

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -14,7 +14,7 @@ import warnings
 
 import numpy as np
 import matplotlib
-matplotlib.use('agg', warn=False)
+matplotlib.use('agg')
 import matplotlib.pyplot as plt
 import pandas
 import IPython

--- a/datascience/util.py
+++ b/datascience/util.py
@@ -7,7 +7,7 @@ __all__ = ['make_array', 'percentile', 'plot_cdf_area', 'plot_normal_cdf',
 import numpy as np
 import pandas as pd
 import matplotlib
-matplotlib.use('agg', warn=False)
+matplotlib.use('agg')
 import matplotlib.pyplot as plt
 from scipy import stats
 from scipy import optimize


### PR DESCRIPTION
[N/A] Wrote test for feature
[N/A] Added changes to CHANGELOG.md
[N/A] Bumped version number (delete if unneeded)

**Changes proposed:**
Removes the warning produced for the deprecation warning in Matplotlib v3.1+.

Will not be pushing new PyPi version specifically for this. Closes #426.
