### PR TITLE
Issue 434

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ extensions = [
 ipython_mplbackend = None
 ipython_execlines = [
   'import matplotlib',
-  'matplotlib.use("Agg", warn=False)',
+  'matplotlib.use("agg")',
   'import numpy as np',
   'import matplotlib.pyplot as plt',
   'plt.style.use("fivethirtyeight")',

--- a/tests/Charts.ipynb
+++ b/tests/Charts.ipynb
@@ -4,18 +4,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/ahemani/Development/data8/datascience/datascience/tables.py:17: MatplotlibDeprecationWarning: The 'warn' parameter of use() is deprecated since Matplotlib 3.1 and will be removed in 3.3.  If any parameter follows 'warn', they should be pass as keyword, not positionally.\n",
-      "  matplotlib.use('agg', warn=False)\n",
-      "/Users/ahemani/Development/data8/datascience/datascience/util.py:10: MatplotlibDeprecationWarning: The 'warn' parameter of use() is deprecated since Matplotlib 3.1 and will be removed in 3.3.  If any parameter follows 'warn', they should be pass as keyword, not positionally.\n",
-      "  matplotlib.use('agg', warn=False)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# HIDDEN\n",
     "from datascience import *\n",


### PR DESCRIPTION
[N/A] Wrote test for feature
[N/A] Added changes to CHANGELOG.md
[N/A] Bumped version number (delete if unneeded)

**Changes proposed:**
Changed the last call of the deprecated warning label that I could for matplotlib in #434 ... but I can't find the usage of it in tests/Charts.ipynb? I think it was output by the first cell when running the code, but it should be gone now. I've reloaded that cell as part of this PR as well. @davidwagner could you please check again?

Closes #434.
