### PR TITLE
fixed warnings in Circle Docstring

### DIFF
--- a/datascience/maps.py
+++ b/datascience/maps.py
@@ -770,7 +770,7 @@ class Circle(Marker):
 
     For example, to draw three circles with circle_marker:
 
-    ..code-block:: python
+    .. code-block:: python
 
         t = Table().with_columns([
                 'lat', [37.8, 38, 37.9],
@@ -783,7 +783,7 @@ class Circle(Marker):
 
     To draw three circles with the circle methods, replace the last line with:
 
-    ..code-block:: python
+    .. code-block:: python
     
         Circle.map_table(t, radius_in_meters=True)
     """

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -2789,7 +2789,7 @@ class Table(collections.abc.MutableMapping):
             Returns:
                 String form of the table
                 
-                The table is just converted to a string with columns seperated by the seperator(argument- default(' | ')) and rows seperated by '\n'
+                The table is just converted to a string with columns seperated by the seperator(argument- default(' | ')) and rows seperated by '\\n'
                 
                 Few examples of the as_text() method are as follows: 
                 1.
@@ -2825,14 +2825,14 @@ class Table(collections.abc.MutableMapping):
 
                 >>> sizes_astext
                 'size   | count\\nsmall  | 50\\nmedium | 100\\nbig    | 50'
-                    
+
                 3. 
                 >>> sizes_astext = sizes.as_text(1)
 
                 >>> sizes_astext
                 'size  | count\\nsmall | 50\\n... (2 rows omitted)'
 
-                 4.
+                4.
                 >>> sizes_astext = sizes.as_text(2, ' - ')
 
                 >>> sizes_astext


### PR DESCRIPTION
Not sure of any of the points below is necessary.

[ ] Wrote test for feature
[ ] Added changes to CHANGELOG.md
[ ] Bumped version number (delete if unneeded)

**Changes proposed:**

Fixed Circle warnings from ticket issue #471 

Also fixed:
```
../datascience/tables.py:docstring of datascience.tables.Table.as_text:11: WARNING: Block quote ends without a blank line; unexpected unindent.
../datascience/tables.py:docstring of datascience.tables.Table.as_text:55: WARNING: Block quote ends without a blank line; unexpected unindent.
```

`make docs` still throws an exception that it was throwing before the changes already.

```
Exception occurred:
  File "_____/opt/anaconda3/envs/ds/lib/python3.8/site-packages/IPython/sphinxext/ipython_directive.py", line 586, in process_input
    raise RuntimeError('Non Expected warning in `{}` line {}'.format(filename, lineno))
RuntimeError: Non Expected warning in `_____/datascience/docs/tutorial.rst` line 229
The full traceback has been saved in /var/folders/_x/9ywl0x0n061d79dp8p99s6vr0000gn/T/sphinx-err-8n2l0o8m.log, if you want to report the issue to the developers.
````

Perhaps there should be a ticket to fix the exception as well.
