### PR TITLE
Fixed compatibility issue with collections.Iterable (Python>=3.10)

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -4626,7 +4626,7 @@ class Table(collections.abc.MutableMapping):
             type(self).plots.append(axis)
         else:
             fig, axes = plt.subplots(n, 1, figsize=(width, height*n))
-            if not isinstance(axes, collections.Iterable):
+            if not isinstance(axes, collections.abc.Iterable):
                 axes=[axes]
             for axis, y_label, color in zip(axes, y_labels, colors):
                 draw(axis, y_label, color)


### PR DESCRIPTION
**Changes proposed:**
In Python 3.10, `collections.Iterable` is deprecated and replacd with `collections.abc.Iterable`. When using `datascience` with Python >=3.10, an error is thrown.

Example:

```
minard = Table.read_table('minard.csv')
minard.scatter('Longitude', 'Latitude')
```

Error: `AttributeError: module 'collections' has no attribute 'Iterable'`

I believe this little fix would solve it.