### PR TITLE
Update badge in README to show status of tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,4 +1,4 @@
-name: Running Test Suite on Pushes
+name: tests
 
 # We run the test suite on every push
 on: [push]

--- a/README.md
+++ b/README.md
@@ -2,16 +2,14 @@
 
 A Berkeley library for introductory data science.
 
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/data-8/datascience?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![Documentation Status](https://readthedocs.org/projects/datascience/badge/?version=master)](http://datascience.readthedocs.org/en/master/?badge=master)
-
 _written by Professor [John DeNero](http://denero.org), Professor
 [David Culler](http://www.cs.berkeley.edu/~culler),
 [Sam Lau](https://github.com/samlau95), and [Alvin Wan](http://alvinwan.com)_
 
 For an example of usage, see the [Berkeley Data 8 class](http://data8.org/).
 
-[![Build Status](https://travis-ci.org/data-8/datascience.svg?branch=master)](https://travis-ci.org/data-8/datascience)
+[![Documentation Status](https://readthedocs.org/projects/datascience/badge/?version=master)](http://datascience.readthedocs.org/en/master/?badge=master)
+[![Build Status](https://github.com/data-8/datascience/actions/workflows/run_tests.yml/badge.svg?branch=master)](https://github.com/data-8/datascience/actions/workflows/run_tests.yml)
 [![Coverage Status](https://coveralls.io/repos/data-8/datascience/badge.svg?branch=master&service=github)](https://coveralls.io/github/data-8/datascience?branch=master)
 
 ## Installation


### PR DESCRIPTION
[n/a] Wrote test for feature
[n/a] Added changes to CHANGELOG.md
[n/a] Bumped version number (delete if unneeded)

**Changes proposed:**
Update the badge in the README, so it reflects the results of the tests run by Github Actions (rather than the old, obsolete, no-longer-used Travis CI).
