### PR TITLE
Updated tutorial.rst with Python 3.6 amendment reference.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -93,8 +93,11 @@ CSVs from URLs are also valid inputs to
 
 ------
 
-It's also possible to add columns from a dictionary, but this option is
-discouraged because dictionaries do not preserve column order.
+It's also possible to add columns from a dictionary. For users< Python 3.6 this method is discouraged because dictionary does not preserve the order.
+
+**Note**- New Dict implementation in Python 3.6 makes it possible for maintaining order of columns in dictionaires. 
+          For more info- Read https://docs.python.org/3.6/whatsnew/3.6.html#whatsnew36-pep468
+
 
 .. ipython:: python
 


### PR DESCRIPTION
Updated "Creating Table" section with the python 3.6 implementation of Dict() which preserves the order. Read docs for further info- https://docs.python.org/3.6/whatsnew/3.6.html#whatsnew36-pep468

[ ] Wrote test for feature
[ ] Added changes to CHANGELOG.md
[ ] Bumped version number (delete if unneeded)

**Changes proposed:**
In Tutorial.rst file under creating table, I made a small change of adding about the recent amendment in python 3.6 where dictionaries preserve the order(new implementation of dict()). Many Students are unaware of it and thus I think that it might be a good start for students or programmers following tutorial.
