### PR TITLE
Fixes Issue 566: `Marker.copy` errors out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### v0.17.6
 * Removed a deprecated function which allowed calling non-table attributes on a table.
+* Fixes bug with copying markers.
 
 ### v0.17.5
 * Eliminated deprecation warnings involved arrays containing arrays/sequences.

--- a/datascience/maps.py
+++ b/datascience/maps.py
@@ -523,7 +523,7 @@ class Marker(_MapFeature):
 
     def copy(self):
         """Return a deep copy"""
-        return type(self)(self.lat_lon[:], **self._attrs)
+        return type(self)(self.lat_lon[0], self.lat_lon[1], **self._attrs)
 
     @property
     def _folium_kwargs(self):

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -124,6 +124,14 @@ def test_circle_map():
     ds.Circle.map(lats, lons).show()
     ds.Circle.map(lats, lons, labels).show()
 
+def test_marker_copy():
+    lat, lon = 51, 52
+    a = ds.Marker(lat, lon)
+    b = a.copy()
+    b_lat_lon = b.lat_lon
+    assert lat == b_lat_lon[0]
+    assert lon == b_lat_lon[1]
+
 
 ##########
 # Region #


### PR DESCRIPTION
[X] Wrote test for bug
[X] Added changes to CHANGELOG.md

**Changes proposed:**
This fixes the bug described in #566.
