### PR TITLE
Remove deprecated function `Table.empty` from `tables.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### v0.17.6
 * Removed a deprecated function which allowed calling non-table attributes on a table.
+* Removed a deprecated function which created an empty table.
 
 ### v0.17.5
 * Eliminated deprecation warnings involved arrays containing arrays/sequences.

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -71,26 +71,6 @@ class Table(collections.abc.MutableMapping):
 
     # Deprecated
     @classmethod
-    def empty(cls, labels=None):
-        """Creates an empty table. Column labels are optional. [Deprecated]
-
-        Args:
-            ``labels`` (None or list): If ``None``, a table with 0
-                columns is created.
-                If a list, each element is a column label in a table with
-                0 rows.
-
-        Returns:
-            A new instance of ``Table``.
-        """
-        warnings.warn("Table.empty(labels) is deprecated. Use Table(labels)", FutureWarning)
-        if labels is None:
-            return cls()
-        values = [[] for label in labels]
-        return cls(values, labels)
-
-    # Deprecated
-    @classmethod
     def from_rows(cls, rows, labels):
         """Create a table from a sequence of rows (fixed-length sequences). [Deprecated]"""
         warnings.warn("Table.from_rows is deprecated. Use Table(labels).with_rows(...)", FutureWarning)


### PR DESCRIPTION
[N/A] Wrote test for feature
[N/A] Added changes to CHANGELOG.md
[N/A] Bumped version number (delete if unneeded)

**Changes proposed:**
Removing a buggy, deprecated function ("Table.empty"). For a long time now, the preferred way of doing this action has been to just call the `Table` initializer function directly with the name of the labels, eg:

```
new_table = Table(["col1", "col2"])
```
