### PR TITLE
Fixes UserWarning for certain charts

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -3620,7 +3620,8 @@ class Table(collections.abc.MutableMapping):
             axis.bar(index-0.5, self[label], 1.0, color=color, **options)
 
         def annotate(axis, ticks):
-            if (ticks is not None) :
+            if (ticks is not None):
+                axis.set_xticks(axis.get_xticks())
                 tick_labels = [ticks[int(l)] if 0<=l<len(ticks) else '' for l in axis.get_xticks()]
                 axis.set_xticklabels(tick_labels, stretch='ultra-condensed')
 
@@ -5840,6 +5841,7 @@ def _vertical_x(axis, ticks=None, max_width=5):
     if (np.array(ticks) == np.rint(ticks)).all():
         ticks = np.rint(ticks).astype(np.int64)
     if max([len(str(tick)) for tick in ticks]) > max_width:
+        axis.set_xticks(ticks)
         axis.set_xticklabels(ticks, rotation='vertical')
 
 ###################


### PR DESCRIPTION
[N/A] Wrote test for feature
[N/A] Added changes to CHANGELOG.md
[N/A] Bumped version number (delete if unneeded)

**Changes proposed:**
This fixes the warning described in #551. This is caused due to a new change in the matplotlib library that shows this UserWarning when not explicitly supplying the ticks with the tick labels. Although this does not cause any detrimental action to the user, we should remove such user warnings when possible.

In this PR, I have make it so that we always set the ticks before the tick labels to the plot. I have tested the change manually in the test/Charts.ipynb as well to ensure that all chart types affected by this UserWarning are fixed. Here's the old chart versus the new chart:

### Old
<img width="840" alt="Screen Shot 2022-12-25 at 12 02 17 PM" src="https://user-images.githubusercontent.com/10746770/209480620-a404ffcc-7eec-4904-b8e0-13732d6f4059.png">

### New
<img width="501" alt="Screen Shot 2022-12-25 at 12 02 48 PM" src="https://user-images.githubusercontent.com/10746770/209480627-c9d2a41b-d8cc-4740-b974-dc408f43135c.png">

