### PR TITLE
testing coverage and cleanup updates tables.py

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -746,9 +746,9 @@ class Table(collections.abc.MutableMapping):
         """
         if inspect.isclass(formatter):
             formatter = formatter()
+        if not hasattr(formatter, 'format_column') and callable(formatter):
+            formatter = _formats.FunctionFormatter(formatter)
         if not hasattr(formatter, 'format_column'):
-            if callable(formatter):
-                formatter = _formats.FunctionFormatter(formatter)
             raise Exception('Expected Formatter or function: ' + str(formatter))
         for label in self._as_labels(column_or_columns):
             if formatter.converts_values:

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -344,13 +344,6 @@ class Table(collections.abc.MutableMapping):
         """
         return tuple(self._columns.keys())
 
-    # Deprecated
-    @property
-    def column_labels(self):
-        """Return a tuple of column labels. [Deprecated]"""
-        warnings.warn("column_labels is deprecated; use labels", FutureWarning)
-        return self.labels
-
     @property
     def num_columns(self):
         """Number of columns."""
@@ -753,9 +746,9 @@ class Table(collections.abc.MutableMapping):
         """
         if inspect.isclass(formatter):
             formatter = formatter()
-        if callable(formatter) and not hasattr(formatter, 'format_column'):
-            formatter = _formats.FunctionFormatter(formatter)
         if not hasattr(formatter, 'format_column'):
+	    if callable(formatter):
+		formatter = _formats.FunctionFormatter(formatter)
             raise Exception('Expected Formatter or function: ' + str(formatter))
         for label in self._as_labels(column_or_columns):
             if formatter.converts_values:

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -747,8 +747,8 @@ class Table(collections.abc.MutableMapping):
         if inspect.isclass(formatter):
             formatter = formatter()
         if not hasattr(formatter, 'format_column'):
-	    if callable(formatter):
-		formatter = _formats.FunctionFormatter(formatter)
+            if callable(formatter):
+                formatter = _formats.FunctionFormatter(formatter)
             raise Exception('Expected Formatter or function: ' + str(formatter))
         for label in self._as_labels(column_or_columns):
             if formatter.converts_values:

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -746,7 +746,7 @@ class Table(collections.abc.MutableMapping):
         """
         if inspect.isclass(formatter):
             formatter = formatter()
-        if not hasattr(formatter, 'format_column') and callable(formatter):
+        if callable(formatter) and not hasattr(formatter, 'format_column'):
             formatter = _formats.FunctionFormatter(formatter)
         if not hasattr(formatter, 'format_column'):
             raise Exception('Expected Formatter or function: ' + str(formatter))


### PR DESCRIPTION
removing depreciated columns_lables. It is not being used anywhere in the code. Should help in boosting the code coverage.

refactoring the following code to avoid redundancy 

`if not hasattr(formatter, 'format_column'):`
`    if callable(formatter):`
`         formatter = _formats.FunctionFormatter(formatter)`
`     raise Exception('Expected Formatter or function: ' + str(formatter))`

[ ] Wrote test for feature
[ ] Added changes to CHANGELOG.md
[ ] Bumped version number (delete if unneeded)

**Changes proposed:**
<description of the PR>
