### PR TITLE
Fix bug #586 - need to call tzset() after setting TZ

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -3,6 +3,7 @@ import re
 import datascience as ds
 from datascience import formats
 import os
+import time
 
 
 def assert_equal(string1, string2):
@@ -95,6 +96,7 @@ def test_date_format():
 def test_date_formatter_format_value():
     formatter = formats.DateFormatter()
     os.environ["TZ"] = "UTC"
+    time.tzset()
     assert_equal(formatter.format_value(1666264489.9004), "2022-10-20 11:14:49.900400")
 
 


### PR DESCRIPTION
**Changes proposed:**
Fix bug in testing code, so it works across platforms, by adding a call to tzset() after setting the TZ environment variable.