### PR TITLE
A test to check that NumberFormater without the format_column method raises an error

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,5 @@
 pytest==7.1.2
+pytest-mock
 coverage
 coveralls
 bokeh

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -7,7 +7,6 @@ from numpy.testing import assert_array_equal
 from datascience import *
 import pandas as pd
 
-
 #########
 # Utils #
 #########
@@ -571,6 +570,12 @@ def test_join(table, table2):
     c      | 3     | 2      | 6
     z      | 1     | 10     | 10
     """)
+
+def test_set_format_with_no_format_column(mocker, table):
+    MockNumberFormatter = mocker.NonCallableMock(spec=NumberFormatter)
+    del MockNumberFormatter.format_column
+    with pytest.raises(Exception):
+        table.set_format('count', MockNumberFormatter)
 
 def test_join_html(table, table2):
     """Test that join doesn't crash with formatting."""

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_array_equal
 from datascience import *
 import pandas as pd
 
+
 #########
 # Utils #
 #########


### PR DESCRIPTION
#476
[x] Wrote test for feature

**Changes proposed:**
Added a test to check that NumberFormater without the format_column method raises an error
