### PR TITLE
Add test for when None is appended to Table object

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -775,6 +775,18 @@ def test_append_row(table):
     g      | 2     | 2
     """)
 
+def test_append_none(table):
+    row = [[], None, "", 0]
+    for i in row:
+        table.append(row)
+        assert_equal(table, """
+                     letter | count | points
+                     a      | 9     | 1
+                     b      | 3     | 2
+                     c      | 3     | 2
+                     z      | 1     | 10
+                     """)
+
 def test_append_row_by_array(table):
     row = np.array(['g', 2, 2])
     table.append(row)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -778,7 +778,7 @@ def test_append_row(table):
 def test_append_none(table):
     row = [[], None, "", 0]
     for i in row:
-        table.append(row)
+        table.append(i)
         assert_equal(table, """
                      letter | count | points
                      a      | 9     | 1


### PR DESCRIPTION
[ ] Wrote test for feature
[ ] Added changes to CHANGELOG.md
[ ] Bumped version number (delete if unneeded)

**Changes proposed:**
This PR adds a simple test case to `test_tables.py` that asserts that, when a `None` type is appended to a Table, it does not return anything, and the Table remains the same.