### PR TITLE
Updating Readme.md file to detail how to get local testing/coverage report

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ Optionally, integrate with Coveralls for code coverage tracking:
 python3 coveralls
 
 That's it! You have now successfully set up your local development environment and generated a test report.
+
+After reviewing the results, you can determine which of the files under the source code folder need more tests based on their corresponding percentages.
+
+Our aim is to have 97% of overall codebase coverage to ensure that there are no discrepencies.
+
+Thank you for considering to help our project, we really appreciate it :)

--- a/README.md
+++ b/README.md
@@ -21,3 +21,45 @@ pip install datascience
 ```
 
 A log of all changes can be found in CHANGELOG.md.
+
+## Setting up Local Development Environment
+
+### For Windows Users
+
+#### Setting up Windows Subsystem for Linux (WSL)
+
+Before proceeding, it's recommended to set up Windows Subsystem for Linux (WSL) for better compatibility with development tools. Follow the official Microsoft documentation to install and set up WSL: [Install Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/install)
+
+Once WSL is set up, open your preferred Linux distribution and continue with the following steps.
+
+#### Installing Required Dependencies
+
+Ensure you have Python, pip, and other necessary tools installed within your WSL environment.
+
+sudo apt update
+sudo apt install python3 python3-pip
+
+### Generating local test report
+
+1. Clone the repository:
+git clone https://github.com/<your_username>/datascience.git
+
+2. Navigate to the project directory
+cd datascience
+
+3. Install required packages:
+pip install -r requirements.txt
+
+4. Run tests using pytest
+python3 pytest
+
+5. Generate coverage report:
+python3 coverage run -m pytest
+
+6. View coverage report:
+python3 coverage report
+
+Optionally, integrate with Coveralls for code coverage tracking:
+python3 coveralls
+
+That's it! You have now successfully set up your local development environment and generated a test report.


### PR DESCRIPTION
[X] Updated Readme.md file

**Changes proposed:**
Before I started developing, I noticed that my Windows OS caused some issues when generating the testing reports. Using pytest/coverage, I got different percentages and even errors. The errors were because some functions that were being used were only available on Unix/Linux systems. So, I had to install WSL and work around this to gain an accurate report. This way, I could add tests more effectively and help get the overall testing coveralls report to 97%.