### PR TITLE
Add a unit test for join method coverage

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -2036,11 +2036,6 @@ class Table(collections.abc.MutableMapping):
 
     def _join(self, column_label, other, other_label=[]):
         """joins when COLUMN_LABEL is a string"""
-        if self.num_rows == 0 or other.num_rows == 0:
-            return None
-        if not other_label:
-            other_label = column_label
-
         self_rows = self.index_by(column_label)
         other_rows = other.index_by(other_label)
         return self._join_helper([column_label], self_rows, other, [other_label], other_rows)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1660,18 +1660,6 @@ def test_join_without_other_label(table, table2):
     2      | c      | 3     | two
     """)
     
-def test_join_empty_tables(table):
-    empty_table = Table().with_columns(['points', []])
-
-    # Temporarily modify the join method to skip the empty table check
-    def modified_join(self, column_label, other, other_label=None):
-        if not other_label:
-            other_label = column_label
-        return self._join(column_label, other, other_label)
-    
-    table.join = modified_join.__get__(table)
-    result = table.join('points', empty_table)
-    assert result is None, "Expected None when one of the tables is empty"
     
 ##################
 # Export/Display #

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1659,8 +1659,20 @@ def test_join_without_other_label(table, table2):
     2      | b      | 3     | two
     2      | c      | 3     | two
     """)
+    
+def test_join_empty_tables(table):
+    empty_table = Table().with_columns(['points', []])
 
-
+    # Temporarily modify the join method to skip the empty table check
+    def modified_join(self, column_label, other, other_label=None):
+        if not other_label:
+            other_label = column_label
+        return self._join(column_label, other, other_label)
+    
+    table.join = modified_join.__get__(table)
+    result = table.join('points', empty_table)
+    assert result is None, "Expected None when one of the tables is empty"
+    
 ##################
 # Export/Display #
 ##################


### PR DESCRIPTION
[O] Wrote test for feature
[ ] Added changes to CHANGELOG.md
[ ] Bumped version number (delete if unneeded)

**Changes proposed:**
Hello, I'm a student and a first-time contributor. 
One of the coverage missing in 'tables.py' is in the '_join' internal method, in lines [2039-2040](https://github.com/data-8/datascience/blob/master/datascience/tables.py#L2039-L2040) where it checks for an empty table. However, the 'join' method for external interface already has these checks in lines [2024-2025](https://github.com/data-8/datascience/blob/master/datascience/tables.py#L2024-L2025), preventing those lines from being covered. This makes it difficult to test '_join' by just calling 'join' as discussed in this [PR](https://github.com/data-8/datascience/pull/615). 

In this unit test, I decided to modify the 'join' method to skip those checks and allow '_join' to be covered. This way, the functionality of _join can be tested without directly invoking it.

Please let me know if any changes are needed to improve this implementation.