### PR TITLE
Normalize row item types to str

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -5709,7 +5709,8 @@ class Table(collections.abc.MutableMapping):
                 index = index_or_label
             else:
                 index = self._table.column_index(index_or_label)
-            return self[index]
+            value = self[index]
+            return value.item() if hasattr(value, 'item') else value
 
         def __repr__(self):
             return 'Row({})'.format(', '.join('{}={}'.format(


### PR DESCRIPTION
Fixes #618 <!-- Needed for GitHub to link the issue to the PR -->

## Normalize row item types to str
This change ensures consistent string type handling between `tbl.row(...).item(...)` and `tbl.column(...).item(...)` operations. Previously, row items returned `numpy.str_` type while column items returned standard Python `str`. The patch modifies the row object to call `.item()` when available (converting numpy types to Python native types) for better consistency and student readability in Data 8 course materials.

---

This change was produced by **Harry Patcher** 🧙‍♂️, an autonomous & anonymous AI engineering agent. No human was involved in creating this pull request.

Learn more about Harry Patcher and how he came up with this fix [here](https://harry-patcher.ai/viewer?url=aHR0cHM6Ly9naXN0LmdpdGh1Yi5jb20vaGFycnktcGF0Y2hlci82NzY1Y2M1NGIwN2U5ZTIwMDgzYjE2NTcwNTFiNzZlNy9yYXcvc3dlYmVuY2hfZGF0YS04X19kYXRhc2NpZW5jZS02MTguanNvbg&amp;pr=aHR0cHM6Ly9naXRodWIuY29tL2RhdGEtOC9kYXRhc2NpZW5jZS9wdWxsLzYzOQ) 🔍.

Harry cannot yet respond to review feedback. If the patch isn’t relevant, reject the PR and optionally [let us know](https://forms.office.com/Pages/ResponsePage.aspx?id=UjyyTqXzvEm1VQsGEmephKlyfnndRsBKt5Fmxu7iHWpUMEdIRzFTUU9LNkxYMDZWQlZWT0gwSFJUTCQlQCN0PWcu&r1e8e3930f96f400aa91b5105dbd09b7d=https%3A//github.com/data-8/datascience/pull/639&rb85bea8de07843f9835f9d001f689f4c=https%3A//github.com/data-8/datascience&r034de175aef248b29aaf36f2a5e92912=https%3A//github.com/data-8/datascience/pull/639&r9e0cc5d7ff8b484e81eb97531d4cefd7=https%3A//github.com/data-8/datascience/pull/639) 📬.