### PR TITLE
Fix ipython directive error by adding blank lines after directives in tutorial.rst (GH#648)

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -403,6 +403,7 @@ The main class in the maps module is the Map class. In this code we create a def
 The maps modules also allows you to make custom maps with markers, circles and regions.
 
 .. ipython:: python
+    
     from datascience.maps import Map, Marker, Circle, Region            # import the Map, Marker, Circle and Region class
     
     # generates markers with custom sets of coordinates, colors and popups


### PR DESCRIPTION
This PR fixes the Sphinx error:
"maximum 4 argument(s) allowed, 17 supplied"
by ensuring a blank line is present after each `.. ipython:: python` directive in tutorial.rst.
