### PR TITLE
Fix plot dimensions for %matplotlib notebook (#538)

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -5533,6 +5533,7 @@ class Table(collections.abc.MutableMapping):
                     type(self).plots.append(axis)
 
         draw_hist(values_dict)
+        plt.tight_layout()  #ensures layout fits for interactive notebook plots
 
     def hist_of_counts(self, *columns, overlay=True, bins=None, bin_column=None,
                        group=None, side_by_side=False, width=None, height=None, **vargs):


### PR DESCRIPTION
This pull request fixes the issue with plot dimensions when using %matplotlib notebook in the datascience package. Now, histograms should display correctly without needing to manually resize the plot.