### PR TITLE
Add tests for Table.apply error handling (#476)

### DIFF
--- a/tests/test_table_apply_errors.py
+++ b/tests/test_table_apply_errors.py
@@ -1,0 +1,21 @@
+import pytest
+from datascience import Table
+
+def test_apply_non_callable():
+    table = Table().with_columns("numbers", [1, 2, 3])
+    with pytest.raises(TypeError):
+        table.apply(123, "numbers")
+
+def test_apply_invalid_column_name():
+    table = Table().with_columns("numbers", [1, 2, 3])
+    with pytest.raises(ValueError):
+        table.apply(lambda x: x, "non_existent_column")
+
+def test_apply_function_returns_invalid_type():
+    table = Table().with_columns("numbers", [1, 2, 3])
+
+    def bad_fn(x):
+        return list(range(x))  
+    with pytest.raises(Exception):
+        table.apply(bad_fn, "numbers")
+


### PR DESCRIPTION
This PR improves the coverage of Table.apply and addresses issue #476. It includes:
A test confirming that passing a non-callable raises a TypeError.
A test verifying that applying to a missing column raises a ValueError.
A test ensuring that inconsistent or invalid return types from the applied function raise an exception.
All new tests pass locally. The remaining failing tests are unrelated to this PR (known issues in maps and doctests).