### PR TITLE
Fix Python 3.14 TypeError for Iterable checks using collections.abc.Iterable

### DIFF
--- a/datascience/util.py
+++ b/datascience/util.py
@@ -14,6 +14,7 @@ from scipy import optimize
 import functools
 import math
 import collections
+from collections.abc import Iterable
 
 # Change matplotlib formatting. TODO incorporate into a style?
 plt.rcParams['patch.force_edgecolor'] = True
@@ -261,11 +262,11 @@ def minimize(f, start=None, smooth=False, log=None, array=False, **vargs):
     else:
         return result.x
 
-def is_non_string_iterable(value):
+def is_non_string_iterable(value: object)-> bool:
     """Returns a boolean value representing whether a value is iterable."""
     if isinstance(value, str):
         return False
-    if hasattr(value, '__iter__'):
+    if isinstance(value, Iterable):
         return True
     return False
 


### PR DESCRIPTION
…terable

[ ] Wrote test for feature
[ ] Added changes to CHANGELOG.md
[ ] Bumped version number (delete if unneeded)

**Changes proposed:**
<description of the PR>
Use `collections.abc.Iterable` instead of `collections.Iterable` for Python 3.14 compatibility.