### PR TITLE
Fix duplicate index check in _lat_lons_from_geojson    

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### v0.18.2
+* Fixed duplicate index check in `_lat_lons_from_geojson` where `s[0]` was validated twice instead of checking both `s[0]` and `s[1]`
+
 ### v0.18.1
 * Added optional `seed` parameter to `sample_proportions()` for reproducible results
 * Added optional `seed` parameter to `proportions_from_distribution()` for reproducible results

--- a/datascience/maps.py
+++ b/datascience/maps.py
@@ -904,7 +904,7 @@ def _lat_lons_from_geojson(s):
 
     GeoJSON coordinates are always stored in (longitude, latitude) order.
     """
-    if len(s) >= 2 and isinstance(s[0], _number) and isinstance(s[0], _number):
+    if len(s) >= 2 and isinstance(s[0], _number) and isinstance(s[1], _number):
         lat, lon = s[1], s[0]
         return [(lat, lon)]
     else:


### PR DESCRIPTION
[ ] Wrote test for feature
[x] Added changes to CHANGELOG.md
[ ] Bumped version number (delete if unneeded)

**Changes proposed:**
 Fixed a duplicate check in _lat_lons_from_geojson where s[0] was checked twice in the coordinate pair validation instead of checking both s[0] and s[1].                                                     
                                                                                                                                                                                                               
  ## Before                                                                                                                                                                                                     
  ```if len(s) >= 2 and isinstance(s[0], _number) and isinstance(s[0], _number): ```                                                                                                                                 
                                                                                                                                                                                                               
  ## After                                                                                                                                                                                                      
  ```if len(s) >= 2 and isinstance(s[0], _number) and isinstance(s[1], _number): ```                                     
