### PR TITLE
Add test for removed `colors` argument in scatter

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -2015,3 +2015,28 @@ def test_with_columns(table):
     t = table.with_columns()
 
     assert table is t
+#New 
+import warnings
+from datascience import Table
+
+
+def test_scatter_colors_warning():
+    t = Table().with_columns(
+        "x", [1, 2, 3],
+        "y", [4, 5, 6]
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        try:
+            t.scatter("x", "y", colors="x")
+        except Exception:
+            # This crash is expected due to matplotlib
+            pass
+
+    # 👇 IMPORTANT: assertion OUTSIDE try block
+    assert any(
+        "removed" in str(warning.message)
+        for warning in w
+    )


### PR DESCRIPTION
This PR adds a test to verify that using the deprecated `colors` argument in scatter raises a warning.

- Captures warning using warnings module
- Ensures backward compatibility behavior is tested

Note: Some unrelated tests are failing due to environment/dependency issues (e.g., folium), but this PR only adds a test for scatter warning behavior.