### PR TITLE
Add test coverage for Table.to_csv

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1960,6 +1960,18 @@ def test_array_roundtrip(table):
         assert_equal(c0, c1)
 
 
+def test_to_csv(table):
+    import tempfile
+    import os
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        filename = os.path.join(tmp_dir, 'test_output.csv')
+        table.to_csv(filename)
+        t = Table.read_table(filename)
+        for (c0, c1) in zip(t.columns, table.columns):
+            assert_equal(c0, c1)
+
+
+
 def test_url_parse():
     """Test that Tables parses URLs correctly"""
     with pytest.raises(ValueError):


### PR DESCRIPTION
- [x] Wrote test for feature

**Changes proposed:**

This PR adds a test for the `to_csv` method, which previously had no test coverage (confirmed via Coveralls). The test verifies that a table written to CSV can be read back using `Table.read_table` and matches the original data.

Related to the ongoing test coverage tracker in #476.