### PR TITLE
Add test coverage for Table._as_label ValueError branch

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -147,6 +147,15 @@ def test_column(table):
     with pytest.raises(ValueError):
         t.column('abc')
 
+def test_as_label(table):
+    """Test table._as_label()"""
+    t = table
+    assert t._as_label('letter') == 'letter'
+    assert t._as_label(0) == 'letter'
+    with pytest.raises(ValueError):
+        t._as_label(3.14)
+
+
 def test_values():
     t1 = Table().with_columns({
         'row1': ['a', 'b', 'c'],


### PR DESCRIPTION
[ ] Wrote test for feature
[ ] Added changes to CHANGELOG.md
[ ] Bumped version number (delete if unneeded)

**Changes proposed:**
   Adds a test for the untested `else` branch in `Table._as_label`, which raises a `ValueError` when passed something that isn't a string or integer.

   Addresses #476.
